### PR TITLE
[#42] Remove SYS_NOT_SUPPORTED return in rule_exec

### DIFF
--- a/libirods_rule_engine_plugin-storage_tiering.cpp
+++ b/libirods_rule_engine_plugin-storage_tiering.cpp
@@ -81,11 +81,6 @@ irods::error exec_rule(
         if("pep_api_data_obj_get_post" == _rn) {
             st.restage_object_to_lowest_tier(_args, rei);
         }
-        else {
-            return ERROR(
-                       SYS_NOT_SUPPORTED,
-                       _rn);
-        }
     }
     catch(const  std::invalid_argument& _e) {
         irods::log(LOG_ERROR, _e.what());

--- a/packaging/test_plugin_storage_tiering.py
+++ b/packaging/test_plugin_storage_tiering.py
@@ -715,10 +715,10 @@ class TestStorageTieringMultipleQueries(ResourceBase, unittest.TestCase):
                 filepath  = lib.create_local_testfile(filename)
                 admin_session.assert_icommand('iput -R ufs0 ' + filename)
                 admin_session.assert_icommand('imeta add -d ' + filename + ' archive_object yes')
-                admin_session.assert_icommand('imeta ls -d ' + filename, 'STDOUT_SINGLELINE', 'AVU')
+                admin_session.assert_icommand('imeta ls -d ' + filename, 'STDOUT_SINGLELINE', 'irods::access_time')
 
                 admin_session.assert_icommand('iput -R ufs0 ' + filename + ' ' + filename2)
-                admin_session.assert_icommand('imeta ls -d ' + filename2, 'STDOUT_SINGLELINE', 'AVU')
+                admin_session.assert_icommand('imeta ls -d ' + filename2, 'STDOUT_SINGLELINE', 'irods::access_time')
 
                 # test stage to tier 1
                 admin_session.assert_icommand('irule -r irods_rule_engine_plugin-storage_tiering-instance -F /var/lib/irods/example_tiering_invocation.r')
@@ -726,7 +726,7 @@ class TestStorageTieringMultipleQueries(ResourceBase, unittest.TestCase):
                 sleep(40)
                 admin_session.assert_icommand('iqstat', 'STDOUT_SINGLELINE', 'No')
                 admin_session.assert_icommand('ils -L ' + filename, 'STDOUT_SINGLELINE', 'ufs1')
-                admin_session.assert_icommand_fail('ils -L ' + filename2, 'STDOUT_SINGLELINE', 'ufs1')
+                admin_session.assert_icommand('ils -L ' + filename2, 'STDOUT_SINGLELINE', 'ufs0')
 
                 sleep(40)
 


### PR DESCRIPTION
Returning an error for non-pep_api_data_obj_get_post operations in exec_rule is not necessarily handling unsupported operations. The "unsupported" operations are applying access time metadata to data objects, but return an error because only pep_api_data_obj_get_post restages data to a different tier. The error has been removed because rule_exists should be catching unsupported rules.

Made tests more specific in order to catch failure to annotate metadata in the future.