### PR TITLE
[#45] Use query limit feature in query iterator (master)

### DIFF
--- a/irods_storage_tiering.cpp
+++ b/irods_storage_tiering.cpp
@@ -480,7 +480,7 @@ namespace irods {
                                           config_.object_limit,
                                           _resource_name);
             if(object_limit.empty()) {
-                return MAX_SQL_ROWS;
+                return 0;
             }
 
             return boost::lexical_cast<uint32_t>(object_limit);
@@ -492,7 +492,7 @@ namespace irods {
         }
         catch(const irods::exception& _e) {
             if(CAT_NO_ROWS_FOUND == _e.code()) {
-                return MAX_SQL_ROWS;
+                return 0;
             }
 
             throw;
@@ -505,10 +505,6 @@ namespace irods {
         ruleExecInfo_t*    _rei ) {
         try {
             const auto query_limit = get_object_limit_for_resource(_source_resource);
-            if (query_limit <= 0) {
-                return;
-            }
-
             const auto query_list  = get_violating_queries_for_resource(_source_resource);
             for(const auto& q_itr : query_list) {
                 const auto  qtype = query::convert_string_to_query_type(q_itr.second);
@@ -516,7 +512,6 @@ namespace irods {
 
                 try {
                     query qobj{comm_, qstring, query_limit, qtype};
-                    uintmax_t obj_ctr = 0;
                     rodsLog(
                         config_.data_transfer_log_level_value,
                         "found %ld objects for resc [%s] with query [%s] type [%d]",
@@ -588,15 +583,6 @@ namespace irods {
                                 _source_resource %
                                 _destination_resource);
                         } // if
-
-                        // if query_limit is not 'unlimited' then exit the loop if
-                        // we have crossed the object limit.
-                        ++obj_ctr;
-                        if(query_limit != MAX_SQL_ROWS &&
-                           obj_ctr >= query_limit) {
-                            rodsLog(LOG_NOTICE, "[%s] - query limit [%d] reached", __FUNCTION__, query_limit);
-                            break;
-                        }
                     } // for result
                 }
                 catch(const exception& _e) {


### PR DESCRIPTION
Instead of tracking the object limit when iterating over results of
violating objects, the object limit can now be used as the query limit
in the vocabulary of the query iterator. The query iterator will cease
once the object limit has been reached. 256 will no longer indicate
"no object limit" - this is now represented by 0.

Also, change tests to fit new definition of 0 in query iterator.

---
[CI tests passed](http://172.25.14.63:8080/job/rule-engine-plugin-storage-tiering-build-test-workflow/246/)