### PR TITLE
Fix test hook (4-2-stable)

### DIFF
--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -74,7 +74,7 @@ def main():
     built_packages_root_directory = options.built_packages_root_directory
     package_suffix = irods_python_ci_utilities.get_package_suffix()
     os_specific_directory = irods_python_ci_utilities.append_os_specific_directory(built_packages_root_directory)
-    irods_python_ci_utilities.install_os_packages_from_files(glob.glob(os.path.join(os_specific_directory, 'irods-rule-engine-plugin-storage-tiering*.{0}'.format(package_suffix))))
+    irods_python_ci_utilities.install_os_packages_from_files(glob.glob(os.path.join(os_specific_directory, 'irods-rule-engine-plugin-*.{0}'.format(package_suffix))))
 
     irods_python_ci_utilities.install_irods_core_dev_repository()
     install_cmake_and_add_to_front_of_path()


### PR DESCRIPTION
[CI tests running](http://172.25.14.63:8080/job/rule-engine-plugin-storage-tiering-build-test-workflow/283/)