### PR TITLE
[#165] Fix scheduled migration via default cpp REP (4-2-stable)

### DIFF
--- a/packaging/test_plugin_unified_storage_tiering.py
+++ b/packaging/test_plugin_unified_storage_tiering.py
@@ -997,6 +997,8 @@ class TestStorageTieringContinueInxMigration(ResourceBase, unittest.TestCase):
                 sleep(5)
                 delay_assert_icommand(admin_session, ['ils', '-l', dirname], 'STDOUT_SINGLELINE', 'ufs1')
                 delay_assert_icommand(admin_session, ['ils', '-l', dirname], 'STDOUT_SINGLELINE', 'ufs0')
+                # Wait for the queue to be emptied and ensure that everything has tiered out from ufs0
+                wait_for_empty_queue(lambda: admin_session.assert_icommand_fail(['ils', '-l', dirname], 'STDOUT', 'ufs0'))
 
                 delay_assert_icommand(admin_session, 'iqdel -a')
 
@@ -1021,6 +1023,8 @@ class TestStorageTieringContinueInxMigration(ResourceBase, unittest.TestCase):
                 sleep(5)
                 delay_assert_icommand(admin_session, ['ils', '-l', dirname], 'STDOUT_SINGLELINE', 'ufs1')
                 delay_assert_icommand(admin_session, ['ils', '-l', dirname], 'STDOUT_SINGLELINE', 'ufs0')
+                # Wait for the queue to be emptied and ensure that everything has tiered out from ufs0
+                wait_for_empty_queue(lambda: admin_session.assert_icommand_fail(['ils', '-l', dirname], 'STDOUT', 'ufs0'))
 
                 delay_assert_icommand(admin_session, 'iqdel -a')
 
@@ -1046,8 +1050,10 @@ class TestStorageTieringContinueInxMigration(ResourceBase, unittest.TestCase):
                 sleep(5)
                 admin_session.assert_icommand('irule -r irods_rule_engine_plugin-unified_storage_tiering-instance -F /var/lib/irods/example_unified_tiering_invocation.r')
                 delay_assert_icommand(admin_session, ['ils', '-l', dirname], 'STDOUT_SINGLELINE', 'ufs1')
-                delay_assert_icommand(admin_session, ['ils', '-l', last_item_path], 'STDOUT_SINGLELINE', 'ufs0')
-                delay_assert_icommand(admin_session, ['ils', '-l', next_to_last_item_path], 'STDOUT_SINGLELINE', 'ufs0')
+                # Wait for the queue to be emptied and ensure that everything has tiered out from ufs0
+                wait_for_empty_queue(lambda: admin_session.assert_icommand(['ils', '-l', next_to_last_item_path], 'STDOUT', 'ufs1'))
+                # Ensure that the item which is 1 past the object_limit did not tier out from ufs0
+                admin_session.assert_icommand(['ils', '-l', last_item_path], 'STDOUT_SINGLELINE', 'ufs0')
 
                 delay_assert_icommand(admin_session, 'iqdel -a')
 

--- a/storage_tiering.cpp
+++ b/storage_tiering.cpp
@@ -676,9 +676,8 @@ namespace irods {
 
         nlohmann::json rule_obj =
         {
-            {"policy", "irods_policy_enqueue_rule"}
-          , {"delay_conditions", _data_movement_params}
-          , {"payload",
+            {"policy_to_invoke", "irods_policy_enqueue_rule"}
+          , {"parameters",
                 {
                     {"rule-engine-operation",     policy::data_movement}
                   , {"rule-engine-instance-name", _plugin_instance_name}
@@ -690,6 +689,7 @@ namespace irods {
                   , {"destination-resource",      _destination_resource}
                   , {"preserve-replicas",         _preserve_replicas}
                   , {"verification-type",         _verification_type}
+                  , {"delay_conditions", _data_movement_params}
                 }
             }
          };


### PR DESCRIPTION
Due to some changes in how scheduling data migrations works, the unified
storage tiering REP needed to be updated in order to work. The following
changes were made:

 - "policy" was changed to "policy_to_invoke" as expected in the cpp
default REP implementation of irods_policy_enqueue_rule
 - "payload" was changed to "parameters" as expected in the cpp default
REP implementation of irods_policy_enqueue_rule
 - "delay_conditions" was moved inside of the "parameters" JSON struct
as expected in the cpp default REP implementation of
irods_policy_enqueue_rule

This causes everything to align as expected in the new world of
policy-composed rule invocation.

CI tests running, but all tests passed at the bench. Fixed all of the log noise that I observed while running at the bench as well.