### PR TITLE
[irods/irods#5828] Explicitly link to libfmt

### DIFF
--- a/unified_storage_tiering.cmake
+++ b/unified_storage_tiering.cmake
@@ -47,6 +47,7 @@ target_link_libraries(
     ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so
     ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_regex.so
     ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
+    ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so
     ${OPENSSL_CRYPTO_LIBRARY}
     Threads::Threads
     irods_common


### PR DESCRIPTION
Workaround for linker error caused by fmt not being passed down as a dependency in irods-dev (irods/irods#5669)