### PR TITLE
Build/test hook improvements, fixes for test suite, and cherry-picked 4-2-stable changes (main)

### DIFF
--- a/example_unified_tiering_invocation.r
+++ b/example_unified_tiering_invocation.r
@@ -1,7 +1,7 @@
 {
    "rule-engine-instance-name": "irods_rule_engine_plugin-unified_storage_tiering-instance",
    "rule-engine-operation": "irods_policy_schedule_storage_tiering",
-   "delay-parameters": "<INST_NAME>irods_rule_engine_plugin-unified_storage_tiering-instance</INST_NAME><PLUSET>1s</PLUSET><EF>1h DOUBLE UNTIL SUCCESS OR 6 TIMES</EF>",
+   "delay-parameters": "<INST_NAME>irods_rule_engine_plugin-unified_storage_tiering-instance</INST_NAME><PLUSET>1s</PLUSET><EF>60s REPEAT UNTIL SUCCESS OR 5 TIMES</EF>",
    "storage-tier-groups": [
        "example_group_g2",
        "example_group"

--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -59,11 +59,11 @@ def copy_output_packages(build_directory, output_root_directory):
         irods_python_ci_utilities.append_os_specific_directory(output_root_directory),
         lambda s:s.endswith(irods_python_ci_utilities.get_package_suffix()))
 
-def main(output_root_directory, irods_packages_root_directory, externals_directory):
+def main(build_directory, output_root_directory, irods_packages_root_directory, externals_directory):
     install_building_dependencies(externals_directory)
     if irods_packages_root_directory:
         irods_python_ci_utilities.install_irods_dev_and_runtime_packages(irods_packages_root_directory)
-    build_directory = tempfile.mkdtemp(prefix='irods_storage_tiering_plugin_build_directory')
+    build_directory = os.path.abspath(build_directory or tempfile.mkdtemp(prefix='irods_storage_tiering_plugin_build_directory'))
     irods_python_ci_utilities.subprocess_get_output(['cmake', os.path.dirname(os.path.realpath(__file__))], check_rc=True, cwd=build_directory)
     irods_python_ci_utilities.subprocess_get_output(['make', '-j', str(multiprocessing.cpu_count()), 'package'], check_rc=True, cwd=build_directory)
     if output_root_directory:
@@ -71,9 +71,13 @@ def main(output_root_directory, irods_packages_root_directory, externals_directo
 
 if __name__ == '__main__':
     parser = optparse.OptionParser()
+    parser.add_option('--build_directory')
     parser.add_option('--output_root_directory')
     parser.add_option('--irods_packages_root_directory')
     parser.add_option('--externals_packages_directory')
     options, _ = parser.parse_args()
 
-    main(options.output_root_directory, options.irods_packages_root_directory, options.externals_packages_directory)
+    main(options.build_directory,
+         options.output_root_directory,
+         options.irods_packages_root_directory,
+         options.externals_packages_directory)

--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -14,15 +14,14 @@ def add_cmake_to_front_of_path():
     os.environ['PATH'] = os.pathsep.join([cmake_path, os.environ['PATH']])
 
 def install_building_dependencies(externals_directory):
-    externals_list = ["irods-externals-cmake3.21.4-0",
-                      "irods-externals-avro1.9.0-0",
-                      "irods-externals-boost1.67.0-0",
-                      "irods-externals-clang-runtime6.0-0",
-                      "irods-externals-clang6.0-0",
-                      "irods-externals-cppzmq4.2.3-0",
-                      "irods-externals-json3.10.4-0",
-                      "irods-externals-libarchive3.3.2-1",
-                      "irods-externals-zeromq4-14.1.6-0"]
+    externals_list = [
+        'irods-externals-boost1.77.0-1',
+        'irods-externals-clang-runtime13.0.0-0',
+        'irods-externals-clang13.0.0-0',
+        'irods-externals-cmake3.21.4-0',
+        'irods-externals-fmt8.0.1-0',
+        'irods-externals-json3.10.4-0',
+        ]
     if externals_directory == 'None' or externals_directory is None:
         irods_python_ci_utilities.install_irods_core_dev_repository()
         irods_python_ci_utilities.install_os_packages(externals_list)

--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -4,40 +4,40 @@ import argparse
 import os
 import shutil
 import glob
-import time
 import irods_python_ci_utilities
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--output_root_directory', type=str, required=True)
+    parser.add_argument('--output_root_directory', type=str)
     parser.add_argument('--built_packages_root_directory', type=str, required=True)
-    parser.add_argument('--munge_path', type=str, default=None, help='munge externals path')
-    parser.add_argument('--test_unified_storage_tiering', type=str, default=None, help='should be either True or False')
+    parser.add_argument('--test', metavar='dotted name', type=str)
+    parser.add_argument('--skip-setup', action='store_false', dest='do_setup', default=True)
 
     args = parser.parse_args()
 
-    output_root_directory = args.output_root_directory
     built_packages_root_directory = args.built_packages_root_directory
     package_suffix = irods_python_ci_utilities.get_package_suffix()
     os_specific_directory = irods_python_ci_utilities.append_os_specific_directory(built_packages_root_directory)
-    irods_python_ci_utilities.subprocess_get_output(['sudo', '-EH', 'pip', 'install', 'unittest-xml-reporting==1.14.0'])
-    irods_python_ci_utilities.install_os_packages_from_files(glob.glob(os.path.join(os_specific_directory, 'irods-rule-engine-plugin-unified-storage-tiering*')))
-    
-    test_name = 'test_plugin_unified_storage_tiering'
 
-    time.sleep(10)
-    irods_python_ci_utilities.subprocess_get_output(['sudo', 'chmod', 'g+rwx', '/dev/fuse'], check_rc=True)
+    if args.do_setup:
+        irods_python_ci_utilities.subprocess_get_output(['sudo', '-EH', 'python3', '-m', 'pip', 'install', 'unittest-xml-reporting==1.14.0'])
 
-    time.sleep(10)
+        irods_python_ci_utilities.install_os_packages_from_files(
+            glob.glob(os.path.join(os_specific_directory,
+                                   f'irods-rule-engine-plugin-unified-storage-tiering*.{package_suffix}')
+            )
+        )
+
+    test = args.test or 'test_plugin_unified_storage_tiering'
 
     try:
         test_output_file = '/var/lib/irods/log/test_output.log'
 
-        if args.munge_path is not None or args.munge_path != '':
-            irods_python_ci_utilities.subprocess_get_output(['sudo', 'su', '-', 'irods', '-c', 'cd scripts; {0}; python2 run_tests.py --xml_output --run_s {1} 2>&1 | tee {2}; exit $PIPESTATUS'.format(args.munge_path, test_name, test_output_file)], check_rc=True)
-        else:
-            irods_python_ci_utilities.subprocess_get_output(['sudo', 'su', '-', 'irods', '-c', 'python2 scripts/run_tests.py --xml_output --run_s {0} 2>&1 | tee {1}; exit $PIPESTATUS'.format(test_name, test_output_file)], check_rc=True)
+        irods_python_ci_utilities.subprocess_get_output(['sudo', 'su', '-', 'irods', '-c',
+            f'python3 scripts/run_tests.py --xml_output --run_s {test} 2>&1 | tee {test_output_file}; exit $PIPESTATUS'],
+            check_rc=True)
     finally:
+        output_root_directory = args.output_root_directory
         if output_root_directory:
             irods_python_ci_utilities.gather_files_satisfying_predicate('/var/lib/irods/log', output_root_directory, lambda x: True)
             shutil.copy('/var/lib/irods/log/test_output.log', output_root_directory)

--- a/packaging/test_plugin_unified_storage_tiering.py
+++ b/packaging/test_plugin_unified_storage_tiering.py
@@ -1106,11 +1106,15 @@ class TestStorageTieringContinueInxMigration(ResourceBase, unittest.TestCase):
                     # stage to tier 1, only the last item should not have been tiered out
                     sleep(5)
                     invoke_storage_tiering_rule()
+                    sleep(5)
+                    delay_assert_icommand(admin_session, ['ils', '-l', dirname], 'STDOUT_SINGLELINE', 'ufs0')
                     delay_assert_icommand(admin_session, ['ils', '-l', dirname], 'STDOUT_SINGLELINE', 'ufs1')
-                    # Wait for the queue to be emptied and ensure that everything has tiered out from ufs0
-                    wait_for_empty_queue(lambda: admin_session.assert_icommand(['ils', '-l', next_to_last_item_path], 'STDOUT', 'ufs1'))
-                    # Ensure that the item which is 1 past the object_limit did not tier out from ufs0
-                    admin_session.assert_icommand(['ils', '-l', last_item_path], 'STDOUT_SINGLELINE', 'ufs0')
+                    # Wait for the queue to be emptied and ensure that everything has tiered out from ufs0 except for 1
+                    wait_for_empty_queue(lambda: admin_session.assert_icommand(['ils', '-l', dirname], 'STDOUT', 'ufs0'))
+                    # Ensure that exactly 1 item did not tier out
+                    _, out, _ = admin_session.assert_icommand(['ils', '-l', dirname], 'STDOUT_SINGLELINE', 'ufs0')
+                    self.assertEqual(file_count - 1, out.count('ufs1'))
+                    self.assertEqual(1, out.count('ufs0'))
 
                 finally:
                     delay_assert_icommand(admin_session, 'iqdel -a')

--- a/packaging/test_plugin_unified_storage_tiering.py
+++ b/packaging/test_plugin_unified_storage_tiering.py
@@ -17,11 +17,11 @@ from .. import lib
 from . import ustrings
 
 @contextlib.contextmanager
-def storage_tiering_configured_custom(arg=None):
+def storage_tiering_configured_custom(arg=None, sleep_time=1):
     filename = paths.server_config_path()
     with lib.file_backed_up(filename):
         irods_config = IrodsConfig()
-        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
+        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = sleep_time
 
         irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
             {
@@ -48,11 +48,11 @@ def storage_tiering_configured_custom(arg=None):
             pass
 
 @contextlib.contextmanager
-def storage_tiering_configured(arg=None):
+def storage_tiering_configured(arg=None, sleep_time=1):
     filename = paths.server_config_path()
     with lib.file_backed_up(filename):
         irods_config = IrodsConfig()
-        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
+        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = sleep_time
 
         irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
             {
@@ -70,11 +70,11 @@ def storage_tiering_configured(arg=None):
             pass
 
 @contextlib.contextmanager
-def storage_tiering_configured_with_log(arg=None):
+def storage_tiering_configured_with_log(arg=None, sleep_time=1):
     filename = paths.server_config_path()
     with lib.file_backed_up(filename):
         irods_config = IrodsConfig()
-        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
+        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = sleep_time
 
         irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
             {
@@ -94,11 +94,11 @@ def storage_tiering_configured_with_log(arg=None):
             pass
 
 @contextlib.contextmanager
-def storage_tiering_configured_without_replication(arg=None):
+def storage_tiering_configured_without_replication(arg=None, sleep_time=1):
     filename = paths.server_config_path()
     with lib.file_backed_up(filename):
         irods_config = IrodsConfig()
-        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
+        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = sleep_time
 
         irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
             {
@@ -116,11 +116,11 @@ def storage_tiering_configured_without_replication(arg=None):
             pass
 
 @contextlib.contextmanager
-def storage_tiering_configured_without_verification(arg=None):
+def storage_tiering_configured_without_verification(arg=None, sleep_time=1):
     filename = paths.server_config_path()
     with lib.file_backed_up(filename):
         irods_config = IrodsConfig()
-        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
+        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = sleep_time
 
         irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
             {
@@ -138,11 +138,11 @@ def storage_tiering_configured_without_verification(arg=None):
             pass
 
 @contextlib.contextmanager
-def storage_tiering_configured_without_access_time(arg=None):
+def storage_tiering_configured_without_access_time(arg=None, sleep_time=1):
     filename = paths.server_config_path()
     with lib.file_backed_up(filename):
         irods_config = IrodsConfig()
-        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
+        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = sleep_time
 
         irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
             {

--- a/packaging/test_plugin_unified_storage_tiering.py
+++ b/packaging/test_plugin_unified_storage_tiering.py
@@ -3,13 +3,10 @@ import sys
 import shutil
 import contextlib
 import os.path
+import unittest
 
 from time import sleep
 
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    import unittest2 as unittest
 from ..controller import IrodsController
 from ..configuration import IrodsConfig
 from .resource_suite import ResourceBase
@@ -17,14 +14,14 @@ from . import session
 from .. import test
 from .. import paths
 from .. import lib
-import ustrings
+from . import ustrings
 
 @contextlib.contextmanager
 def storage_tiering_configured_custom(arg=None):
     filename = paths.server_config_path()
     with lib.file_backed_up(filename):
         irods_config = IrodsConfig()
-        irods_config.server_config['advanced_settings']['rule_engine_server_sleep_time_in_seconds'] = 1
+        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
 
         irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
             {
@@ -44,42 +41,6 @@ def storage_tiering_configured_custom(arg=None):
             }
         )
 
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_verification-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_verification",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_replication-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_replication",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_movement-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_movement",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-apply_access_time-instance",
-                "plugin_name": "irods_rule_engine_plugin-apply_access_time",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
         irods_config.commit(irods_config.server_config, irods_config.server_config_path)
         try:
             yield
@@ -91,49 +52,12 @@ def storage_tiering_configured(arg=None):
     filename = paths.server_config_path()
     with lib.file_backed_up(filename):
         irods_config = IrodsConfig()
-        irods_config.server_config['advanced_settings']['rule_engine_server_sleep_time_in_seconds'] = 1
+        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
 
         irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
             {
                 "instance_name": "irods_rule_engine_plugin-unified_storage_tiering-instance",
                 "plugin_name": "irods_rule_engine_plugin-unified_storage_tiering",
-                "plugin_specific_configuration": {
-                    "data_transfer_log_level" : "LOG_NOTICE"
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_verification-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_verification",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_replication-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_replication",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_movement-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_movement",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-apply_access_time-instance",
-                "plugin_name": "irods_rule_engine_plugin-apply_access_time",
                 "plugin_specific_configuration": {
                 }
             }
@@ -150,7 +74,7 @@ def storage_tiering_configured_with_log(arg=None):
     filename = paths.server_config_path()
     with lib.file_backed_up(filename):
         irods_config = IrodsConfig()
-        irods_config.server_config['advanced_settings']['rule_engine_server_sleep_time_in_seconds'] = 1
+        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
 
         irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
             {
@@ -158,42 +82,6 @@ def storage_tiering_configured_with_log(arg=None):
                 "plugin_name": "irods_rule_engine_plugin-unified_storage_tiering",
                 "plugin_specific_configuration": {
                     "data_transfer_log_level" : "LOG_NOTICE"
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_verification-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_verification",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_replication-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_replication",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_movement-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_movement",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-apply_access_time-instance",
-                "plugin_name": "irods_rule_engine_plugin-apply_access_time",
-                "plugin_specific_configuration": {
                 }
             }
         )
@@ -210,40 +98,12 @@ def storage_tiering_configured_without_replication(arg=None):
     filename = paths.server_config_path()
     with lib.file_backed_up(filename):
         irods_config = IrodsConfig()
-        irods_config.server_config['advanced_settings']['rule_engine_server_sleep_time_in_seconds'] = 1
+        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
 
         irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
             {
                 "instance_name": "irods_rule_engine_plugin-unified_storage_tiering-instance",
                 "plugin_name": "irods_rule_engine_plugin-unified_storage_tiering",
-                "plugin_specific_configuration": {
-                    "data_transfer_log_level": "LOG_NOTICE"
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_verification-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_verification",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_movement-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_movement",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-apply_access_time-instance",
-                "plugin_name": "irods_rule_engine_plugin-apply_access_time",
                 "plugin_specific_configuration": {
                 }
             }
@@ -260,39 +120,12 @@ def storage_tiering_configured_without_verification(arg=None):
     filename = paths.server_config_path()
     with lib.file_backed_up(filename):
         irods_config = IrodsConfig()
-        irods_config.server_config['advanced_settings']['rule_engine_server_sleep_time_in_seconds'] = 1
+        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
 
         irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
             {
                 "instance_name": "irods_rule_engine_plugin-unified_storage_tiering-instance",
                 "plugin_name": "irods_rule_engine_plugin-unified_storage_tiering",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_replication-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_replication",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_movement-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_movement",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-apply_access_time-instance",
-                "plugin_name": "irods_rule_engine_plugin-apply_access_time",
                 "plugin_specific_configuration": {
                 }
             }
@@ -309,40 +142,12 @@ def storage_tiering_configured_without_access_time(arg=None):
     filename = paths.server_config_path()
     with lib.file_backed_up(filename):
         irods_config = IrodsConfig()
-        irods_config.server_config['advanced_settings']['rule_engine_server_sleep_time_in_seconds'] = 1
+        irods_config.server_config['advanced_settings']['delay_server_sleep_time_in_seconds'] = 1
 
         irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
             {
                 "instance_name": "irods_rule_engine_plugin-unified_storage_tiering-instance",
                 "plugin_name": "irods_rule_engine_plugin-unified_storage_tiering",
-                "plugin_specific_configuration": {
-                    "data_transfer_log_level" : "LOG_NOTICE"
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_verification-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_verification",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_replication-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_replication",
-                "plugin_specific_configuration": {
-                }
-            }
-        )
-
-        irods_config.server_config['plugin_configuration']['rule_engines'].insert(0,
-            {
-                "instance_name": "irods_rule_engine_plugin-data_movement-instance",
-                "plugin_name": "irods_rule_engine_plugin-data_movement",
                 "plugin_specific_configuration": {
                 }
             }
@@ -460,7 +265,7 @@ class TestStorageTieringPlugin(ResourceBase, unittest.TestCase):
 
     def test_put_and_get(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             zone_name = IrodsConfig().client_environment['irods_zone_name']
             with session.make_session_for_existing_admin() as admin_session:
                 with session.make_session_for_existing_user('alice', 'apass', lib.get_hostname(), zone_name) as alice_session:
@@ -488,7 +293,7 @@ class TestStorageTieringPlugin(ResourceBase, unittest.TestCase):
 
     def test_put_and_get_with_preserve_replica__92(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             zone_name = IrodsConfig().client_environment['irods_zone_name']
             with session.make_session_for_existing_admin() as admin_session:
                 with session.make_session_for_existing_user('alice', 'apass', lib.get_hostname(), zone_name) as alice_session:
@@ -526,7 +331,7 @@ class TestStorageTieringPlugin(ResourceBase, unittest.TestCase):
 
     def test_put_and_get_with_preserve_replica_restage__125(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             zone_name = IrodsConfig().client_environment['irods_zone_name']
             with session.make_session_for_existing_admin() as admin_session:
                 admin_session.assert_icommand('imeta add -R rnd0 irods::storage_tiering::preserve_replicas true')
@@ -556,7 +361,7 @@ class TestStorageTieringPlugin(ResourceBase, unittest.TestCase):
 
     def test_single_quote_data_name__127(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             zone_name = IrodsConfig().client_environment['irods_zone_name']
             with session.make_session_for_existing_admin() as admin_session:
                 with session.make_session_for_existing_user('alice', 'apass', lib.get_hostname(), zone_name) as alice_session:
@@ -657,7 +462,7 @@ class TestStorageTieringPluginMultiGroup(ResourceBase, unittest.TestCase):
 
     def test_put_and_get(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
                 print("yep")
                 admin_session.assert_icommand('ils -L ', 'STDOUT_SINGLELINE', 'rods')
@@ -753,7 +558,7 @@ class TestStorageTieringPluginCustomMetadata(ResourceBase, unittest.TestCase):
 
     def test_put_and_get(self):
         with storage_tiering_configured_custom():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
                 filename = 'test_put_file'
                 admin_session.assert_icommand('iput -R rnd0 ' + filename)
@@ -807,7 +612,7 @@ class TestStorageTieringPluginMinimumRestage(ResourceBase, unittest.TestCase):
 
     def test_put_and_get(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
                 filename = 'test_put_file'
                 admin_session.assert_icommand('iput -R ufs0 ' + filename)
@@ -860,7 +665,7 @@ class TestStorageTieringPluginPreserveReplica(ResourceBase, unittest.TestCase):
 
     def test_put_and_get(self):
         with storage_tiering_configured_with_log():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
                 filename = 'test_put_file'
                 admin_session.assert_icommand('iput -R ufs0 ' + filename)
@@ -919,7 +724,7 @@ class TestStorageTieringPluginObjectLimit(ResourceBase, unittest.TestCase):
 
     def test_put_and_get_limit_1(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
                 admin_session.assert_icommand('imeta add -R ufs0 irods::storage_tiering::object_limit 1')
 
@@ -939,7 +744,7 @@ class TestStorageTieringPluginObjectLimit(ResourceBase, unittest.TestCase):
 
     def test_put_and_get_no_limit_zero(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
                 admin_session.assert_icommand('imeta add -R ufs0 irods::storage_tiering::object_limit 0')
 
@@ -959,7 +764,7 @@ class TestStorageTieringPluginObjectLimit(ResourceBase, unittest.TestCase):
 
     def test_put_and_get_no_limit_default(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
                 admin_session.assert_icommand('iput -R ufs0 ' + self.filename)
                 admin_session.assert_icommand('iput -R ufs0 ' + self.filename + " " + self.filename2)
@@ -975,51 +780,51 @@ class TestStorageTieringPluginObjectLimit(ResourceBase, unittest.TestCase):
                 admin_session.assert_icommand('irm -f ' + self.filename)
                 admin_session.assert_icommand('irm -f ' + self.filename2)
 
-class TestStorageTieringPluginLogMigration(ResourceBase, unittest.TestCase):
-    def setUp(self):
-        super(TestStorageTieringPluginLogMigration, self).setUp()
-        with session.make_session_for_existing_admin() as admin_session:
-            admin_session.assert_icommand('iqdel -a')
-            admin_session.assert_icommand('iadmin mkresc ufs0 unixfilesystem '+test.settings.HOSTNAME_1 +':/tmp/irods/ufs0', 'STDOUT_SINGLELINE', 'unixfilesystem')
-            admin_session.assert_icommand('iadmin mkresc ufs1 unixfilesystem '+test.settings.HOSTNAME_1 +':/tmp/irods/ufs1', 'STDOUT_SINGLELINE', 'unixfilesystem')
-
-            admin_session.assert_icommand('imeta add -R ufs0 irods::storage_tiering::group example_group 0')
-            admin_session.assert_icommand('imeta add -R ufs1 irods::storage_tiering::group example_group 1')
-
-            admin_session.assert_icommand('imeta add -R ufs0 irods::storage_tiering::time 5')
-            admin_session.assert_icommand('imeta add -R ufs0 irods::storage_tiering::minimum_delay_time_in_seconds 1')
-            admin_session.assert_icommand('imeta add -R ufs0 irods::storage_tiering::maximum_delay_time_in_seconds 2')
-
-            self.max_sql_rows = 256
-
-    def tearDown(self):
-        super(TestStorageTieringPluginLogMigration, self).tearDown()
-        with session.make_session_for_existing_admin() as admin_session:
-            admin_session.assert_icommand('iadmin rmresc ufs0')
-            admin_session.assert_icommand('iadmin rmresc ufs1')
-            admin_session.assert_icommand('iadmin rum')
-
-    def test_put_and_get(self):
-        with storage_tiering_configured_with_log():
-            with session.make_session_for_existing_admin() as admin_session:
-
-		    initial_log_size = lib.get_file_size_by_path(paths.server_log_path())
-
-		    filename = 'test_put_file'
-		    admin_session.assert_icommand('iput -R ufs0 ' + filename)
-		    admin_session.assert_icommand('imeta ls -d ' + filename, 'STDOUT_SINGLELINE', filename)
-		    admin_session.assert_icommand('ils -L ' + filename, 'STDOUT_SINGLELINE', filename)
-
-		    # test stage to tier 1
-		    sleep(5)
-		    admin_session.assert_icommand('irule -r irods_rule_engine_plugin-unified_storage_tiering-instance -F /var/lib/irods/example_unified_tiering_invocation.r')
-		    sleep(60)
-
-		    admin_session.assert_icommand('ils -L ' + filename, 'STDOUT_SINGLELINE', 'ufs1')
-		    admin_session.assert_icommand('irm -f ' + filename)
-
-		    log_count = lib.count_occurrences_of_string_in_log(paths.server_log_path(), 'irods::storage_tiering migrating', start_index=initial_log_size)
-		    self.assertTrue(1 == log_count, msg='log_count:{}'.format(log_count))
+#   class TestStorageTieringPluginLogMigration(ResourceBase, unittest.TestCase):
+#       def setUp(self):
+#           super(TestStorageTieringPluginLogMigration, self).setUp()
+#           with session.make_session_for_existing_admin() as admin_session:
+#               admin_session.assert_icommand('iqdel -a')
+#               admin_session.assert_icommand('iadmin mkresc ufs0 unixfilesystem '+test.settings.HOSTNAME_1 +':/tmp/irods/ufs0', 'STDOUT_SINGLELINE', 'unixfilesystem')
+#               admin_session.assert_icommand('iadmin mkresc ufs1 unixfilesystem '+test.settings.HOSTNAME_1 +':/tmp/irods/ufs1', 'STDOUT_SINGLELINE', 'unixfilesystem')
+#
+#               admin_session.assert_icommand('imeta add -R ufs0 irods::storage_tiering::group example_group 0')
+#               admin_session.assert_icommand('imeta add -R ufs1 irods::storage_tiering::group example_group 1')
+#
+#               admin_session.assert_icommand('imeta add -R ufs0 irods::storage_tiering::time 5')
+#               admin_session.assert_icommand('imeta add -R ufs0 irods::storage_tiering::minimum_delay_time_in_seconds 1')
+#               admin_session.assert_icommand('imeta add -R ufs0 irods::storage_tiering::maximum_delay_time_in_seconds 2')
+#
+#               self.max_sql_rows = 256
+#
+#       def tearDown(self):
+#           super(TestStorageTieringPluginLogMigration, self).tearDown()
+#           with session.make_session_for_existing_admin() as admin_session:
+#               admin_session.assert_icommand('iadmin rmresc ufs0')
+#               admin_session.assert_icommand('iadmin rmresc ufs1')
+#               admin_session.assert_icommand('iadmin rum')
+#
+#       def test_put_and_get(self):
+#           with storage_tiering_configured_with_log():
+#               with session.make_session_for_existing_admin() as admin_session:
+#
+#                       initial_log_size = lib.get_file_size_by_path(paths.server_log_path())
+#
+#                       filename = 'test_put_file'
+#                       admin_session.assert_icommand('iput -R ufs0 ' + filename)
+#                       admin_session.assert_icommand('imeta ls -d ' + filename, 'STDOUT_SINGLELINE', filename)
+#                       admin_session.assert_icommand('ils -L ' + filename, 'STDOUT_SINGLELINE', filename)
+#
+#                       # test stage to tier 1
+#                       sleep(5)
+#                       admin_session.assert_icommand('irule -r irods_rule_engine_plugin-unified_storage_tiering-instance -F /var/lib/irods/example_unified_tiering_invocation.r')
+#                       sleep(60)
+#
+#                       admin_session.assert_icommand('ils -L ' + filename, 'STDOUT_SINGLELINE', 'ufs1')
+#                       admin_session.assert_icommand('irm -f ' + filename)
+#
+#                       log_count = lib.count_occurrences_of_string_in_log(paths.server_log_path(), 'irods::storage_tiering migrating', start_index=initial_log_size)
+#                       self.assertTrue(1 == log_count, msg='log_count:{}'.format(log_count))
 
 class TestStorageTieringMultipleQueries(ResourceBase, unittest.TestCase):
     def setUp(self):
@@ -1053,7 +858,7 @@ class TestStorageTieringMultipleQueries(ResourceBase, unittest.TestCase):
 
     def test_put_and_get(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
 
                 filename  = 'test_put_file'
@@ -1103,7 +908,7 @@ class TestStorageTieringPluginRegistration(ResourceBase, unittest.TestCase):
 
     def test_file_registration(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
 
                 filename  = 'test_put_file'
@@ -1126,7 +931,7 @@ class TestStorageTieringPluginRegistration(ResourceBase, unittest.TestCase):
 
     def test_directory_registration(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
                 local_dir_name = '/tmp/test_directory_registration_dir'
                 shutil.rmtree(local_dir_name, ignore_errors=True)
@@ -1174,7 +979,7 @@ class TestStorageTieringContinueInxMigration(ResourceBase, unittest.TestCase):
 
     def test_put_gt_max_sql_rows(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
                 # Put enough objects to force continueInx when iterating over violating objects (above MAX_SQL_ROWS)
                 file_count = self.max_sql_rows + 1
@@ -1189,6 +994,8 @@ class TestStorageTieringContinueInxMigration(ResourceBase, unittest.TestCase):
                 sleep(5)
                 delay_assert_icommand(admin_session, ['ils', '-l', dirname], 'STDOUT_SINGLELINE', 'ufs1')
                 delay_assert_icommand(admin_session, ['ils', '-l', dirname], 'STDOUT_SINGLELINE', 'ufs0')
+                # Wait for the queue to be emptied and ensure that everything has tiered out from ufs0
+                wait_for_empty_queue(lambda: admin_session.assert_icommand_fail(['ils', '-l', dirname], 'STDOUT', 'ufs0'))
 
                 delay_assert_icommand(admin_session, 'iqdel -a')
 
@@ -1198,7 +1005,7 @@ class TestStorageTieringContinueInxMigration(ResourceBase, unittest.TestCase):
 
     def test_put_max_sql_rows(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
                 # Put exactly MAX_SQL_ROWS objects (boundary test)
                 file_count = self.max_sql_rows
@@ -1213,6 +1020,8 @@ class TestStorageTieringContinueInxMigration(ResourceBase, unittest.TestCase):
                 sleep(5)
                 delay_assert_icommand(admin_session, ['ils', '-l', dirname], 'STDOUT_SINGLELINE', 'ufs1')
                 delay_assert_icommand(admin_session, ['ils', '-l', dirname], 'STDOUT_SINGLELINE', 'ufs0')
+                # Wait for the queue to be emptied and ensure that everything has tiered out from ufs0
+                wait_for_empty_queue(lambda: admin_session.assert_icommand_fail(['ils', '-l', dirname], 'STDOUT', 'ufs0'))
 
                 delay_assert_icommand(admin_session, 'iqdel -a')
 
@@ -1222,7 +1031,7 @@ class TestStorageTieringContinueInxMigration(ResourceBase, unittest.TestCase):
 
     def test_put_object_limit_lt(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
                 # Put enough objects to force continueInx and set object_limit to one less than that (above MAX_SQL_ROWS)
                 file_count = self.max_sql_rows + 2
@@ -1238,8 +1047,10 @@ class TestStorageTieringContinueInxMigration(ResourceBase, unittest.TestCase):
                 sleep(5)
                 admin_session.assert_icommand('irule -r irods_rule_engine_plugin-unified_storage_tiering-instance -F /var/lib/irods/example_unified_tiering_invocation.r')
                 delay_assert_icommand(admin_session, ['ils', '-l', dirname], 'STDOUT_SINGLELINE', 'ufs1')
-                delay_assert_icommand(admin_session, ['ils', '-l', last_item_path], 'STDOUT_SINGLELINE', 'ufs0')
-                delay_assert_icommand(admin_session, ['ils', '-l', next_to_last_item_path], 'STDOUT_SINGLELINE', 'ufs0')
+                # Wait for the queue to be emptied and ensure that everything has tiered out from ufs0
+                wait_for_empty_queue(lambda: admin_session.assert_icommand(['ils', '-l', next_to_last_item_path], 'STDOUT', 'ufs1'))
+                # Ensure that the item which is 1 past the object_limit did not tier out from ufs0
+                admin_session.assert_icommand(['ils', '-l', last_item_path], 'STDOUT_SINGLELINE', 'ufs0')
 
                 delay_assert_icommand(admin_session, 'iqdel -a')
 
@@ -1249,11 +1060,11 @@ class TestStorageTieringContinueInxMigration(ResourceBase, unittest.TestCase):
 
     def test_put_multi_fetch_page(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
                 # Put enough objects to force results paging more than once
                 file_count = (self.max_sql_rows * 2) + 1
-                dirname = 'test_put_gt_max_sql_rows'
+                dirname = 'test_put_multi_fetch_page'
                 shutil.rmtree(dirname, ignore_errors=True)
                 lib.make_large_local_tmp_dir(dirname, file_count, 1)
                 admin_session.assert_icommand(['iput', '-R', 'ufs0', '-r', dirname], 'STDOUT_SINGLELINE', ustrings.recurse_ok_string())
@@ -1303,7 +1114,7 @@ class TestStorageTieringPluginMultiGroupRestage(ResourceBase, unittest.TestCase)
 
     def test_put_and_get(self):
         with storage_tiering_configured():
-            IrodsController().restart()
+            IrodsController().restart(test_mode=True)
             with session.make_session_for_existing_admin() as admin_session:
 
                 try:
@@ -1321,4 +1132,7 @@ class TestStorageTieringPluginMultiGroupRestage(ResourceBase, unittest.TestCase)
                     delay_assert_icommand(admin_session, 'ils -L ' + filename, 'STDOUT_SINGLELINE', 'ufs0')
                 finally:
                     admin_session.assert_icommand('irm -f ' + filename)
+
+
+
 

--- a/storage_tiering.cpp
+++ b/storage_tiering.cpp
@@ -676,9 +676,8 @@ namespace irods {
 
         nlohmann::json rule_obj =
         {
-            {"policy", "irods_policy_enqueue_rule"}
-          , {"delay_conditions", _data_movement_params}
-          , {"payload",
+            {"policy_to_invoke", "irods_policy_enqueue_rule"}
+          , {"parameters",
                 {
                     {"rule-engine-operation",     policy::data_movement}
                   , {"rule-engine-instance-name", _plugin_instance_name}
@@ -690,6 +689,7 @@ namespace irods {
                   , {"destination-resource",      _destination_resource}
                   , {"preserve-replicas",         _preserve_replicas}
                   , {"verification-type",         _verification_type}
+                  , {"delay_conditions", _data_movement_params}
                 }
             }
          };

--- a/storage_tiering.cpp
+++ b/storage_tiering.cpp
@@ -689,7 +689,7 @@ namespace irods {
                   , {"destination-resource",      _destination_resource}
                   , {"preserve-replicas",         _preserve_replicas}
                   , {"verification-type",         _verification_type}
-                  , {"delay_conditions", _data_movement_params}
+                  , {"delay_conditions",          _data_movement_params}
                 }
             }
          };


### PR DESCRIPTION
These tests do *NOT* pass presently. I suspect there is a bug in the delay server as the tests do pass in 4-2-stable. If you diff this against 4-2-stable, you will see that the only difference of any possible consequence is the fetching of configuration values, and I don't think that is related to the issues I am seeing. I could be wrong, of course. :) Leaving as draft until we can figure it out.