### PR TITLE
[#206] Make test results consistent (main)

### DIFF
--- a/packaging/test_plugin_unified_storage_tiering.py
+++ b/packaging/test_plugin_unified_storage_tiering.py
@@ -440,6 +440,9 @@ class TestStorageTieringPlugin(ResourceBase, unittest.TestCase):
                         access_time = out.strip()
                         self.assertGreater(len(access_time), 0)
 
+                        # sleeping guarantees the access time will be different following the call to irepl.
+                        sleep(2)
+
                         # show the access time is updated correctly.
                         lib.create_ufs_resource(admin_session, resc_name)
                         admin_session.assert_icommand(f'irepl -M -R {resc_name} {alice_session.home_collection}/{filename}')


### PR DESCRIPTION
This tweak was taken from #224.

Without this, it's possible for the test to fail due to the access time not appearing to change. The real issue is that the access time doesn't provide enough accuracy to detect fast changes.