### PR TITLE
Implement storage tiering for data from remote zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ imeta add -R medium_resc irods::storage_tiering::minimum_restage_tier true
 
 A tier within a tier group may identify data objects which are in violation by an alternate mechanism beyond the built-in time-based constraint.  This allows the data grid administrator to take additional context into account when identifying data objects to migrate.
 
-Data objects which have been labeled via particular metadata, or within a specific collection, owned by a particular user, or belonging to a particular project may be identified through a custom query.  The default attribute **irods::storage_tiering::query** is used to hold this custom query.  To configure the custom query, attach the query to the root resource of the tier within the tier group.  This query will be used in place of the default time-based query for that tier.  For efficiency this example query checks for the existence in the root resource's list of leaves by resource ID.  Please note that any custom query must return DATA_NAME, COLL_NAME, USER_NAME, DATA_REPL_NUM in that order as it is a convention of this rule engine plugin.
+Data objects which have been labeled via particular metadata, or within a specific collection, owned by a particular user, or belonging to a particular project may be identified through a custom query.  The default attribute **irods::storage_tiering::query** is used to hold this custom query.  To configure the custom query, attach the query to the root resource of the tier within the tier group.  This query will be used in place of the default time-based query for that tier.  For efficiency this example query checks for the existence in the root resource's list of leaves by resource ID.  Please note that any custom query must return DATA_NAME, COLL_NAME, USER_NAME, USER_ZONE, DATA_REPL_NUM in that order as it is a convention of this rule engine plugin.
 
 ```
-imeta set -R fast_resc irods::storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, DATA_REPL_NUM WHERE META_DATA_ATTR_NAME = 'irods::access_time' AND META_DATA_ATTR_VALUE < 'TIME_CHECK_STRING' AND DATA_RESC_ID IN ('10068', '10069')"
+imeta set -R fast_resc irods::storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, USER_ZONE, DATA_REPL_NUM WHERE META_DATA_ATTR_NAME = 'irods::access_time' AND META_DATA_ATTR_VALUE < 'TIME_CHECK_STRING' AND DATA_RESC_ID IN ('10068', '10069')"
 ```
 
 The example above implements the default query.  Note that the string `TIME_CHECK_STRING` is used in place of an actual time.  This string will be replaced by the storage tiering framework with the appropriately computed time given the previous parameters.
@@ -171,13 +171,13 @@ The example above implements the default query.  Note that the string `TIME_CHEC
 Any number of queries may be attached in order provide a range of criteria by which data may be tiered, such as user applied metadata.  To allow a user to archive their own data via metadata they may tag an object such as `archive_object true`.  The tier may then have a query added to support this.
 
 ```
-imeta set -R fast_resc irods::storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, DATA_REPL_NUM WHERE META_DATA_ATTR_NAME = 'archive_object' AND META_DATA_ATTR_VALUE = 'true' AND DATA_RESC_ID IN ('10068', '10069')"
+imeta set -R fast_resc irods::storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, USER_ZONE, DATA_REPL_NUM WHERE META_DATA_ATTR_NAME = 'archive_object' AND META_DATA_ATTR_VALUE = 'true' AND DATA_RESC_ID IN ('10068', '10069')"
 ```
 
 Queries may also be provided by using the Specific Query interface within iRODS.  The archive object query may be stored by an iRODS administrator as follows.
 
 ```
-'iadmin asq "SELECT DATA_NAME, COLL_NAME, USER_NAME, DATA_REPL_NUM WHERE META_DATA_ATTR_NAME = 'archive_object' AND META_DATA_ATTR_VALUE = 'true' AND DATA_RESC_ID IN ('10068', '10069')" archive_query
+'iadmin asq "SELECT DATA_NAME, COLL_NAME, USER_NAME, USER_ZONE, DATA_REPL_NUM WHERE META_DATA_ATTR_NAME = 'archive_object' AND META_DATA_ATTR_VALUE = 'true' AND DATA_RESC_ID IN ('10068', '10069')" archive_query
 ```
 
 At which point the query attached to the root of a storage tier would require the use of a metadata unit of `specific`:

--- a/libirods_rule_engine_plugin-unified_storage_tiering.cpp
+++ b/libirods_rule_engine_plugin-unified_storage_tiering.cpp
@@ -351,6 +351,7 @@ namespace {
         const std::string& _instance_name,
         const std::string& _object_path,
         const std::string& _user_name,
+        const std::string& _user_zone,
         const std::string& _source_replica_number,
         const std::string& _source_resource,
         const std::string& _destination_resource,
@@ -420,13 +421,14 @@ namespace {
                 parser.first_resc(source_resource);
 
                 auto proxy_conn = irods::proxy_connection();
-                rcComm_t* comm = proxy_conn.make(_rei->rsComm->clientUser.userName);
+                rcComm_t* comm = proxy_conn.make(_rei->rsComm->clientUser.userName, _rei->rsComm->clientUser.rodsZone);
 
                 irods::storage_tiering st{comm, _rei, plugin_instance_name};
 
                 st.migrate_object_to_minimum_restage_tier(
                     object_path,
                     _rei->rsComm->clientUser.userName,
+                    _rei->rsComm->clientUser.rodsZone,
                     source_resource);
             }
             else if("pep_api_data_obj_open_post"   == _rn ||
@@ -468,12 +470,13 @@ namespace {
                     auto [object_path, resource_name] = opened_objects[l1_idx];
 
                     auto proxy_conn = irods::proxy_connection();
-                    rcComm_t* comm = proxy_conn.make(_rei->rsComm->clientUser.userName);
+                    rcComm_t* comm = proxy_conn.make(_rei->rsComm->clientUser.userName, _rei->rsComm->clientUser.rodsZone);
 
                     irods::storage_tiering st{comm, _rei, plugin_instance_name};
                     st.migrate_object_to_minimum_restage_tier(
                         object_path,
                         _rei->rsComm->clientUser.userName,
+                        _rei->rsComm->clientUser.rodsZone,
                         resource_name);
                 }
             }
@@ -492,6 +495,7 @@ namespace {
         const std::string& _group_name,
         const std::string& _object_path,
         const std::string& _user_name,
+        const std::string& _user_zone,
         const std::string& _source_replica_number,
         const std::string& _source_resource,
         const std::string& _destination_resource) {
@@ -499,6 +503,7 @@ namespace {
             _group_name,
             _object_path,
             _user_name,
+            _user_zone,
             _source_replica_number,
             _source_resource,
             _destination_resource);
@@ -714,19 +719,21 @@ irods::error exec_rule_expression(
                 irods::storage_tiering::policy::data_movement ==
                 rule_obj.at("rule-engine-operation")) {
             try {
-                // proxy for provided user name
+                // proxy for provided user name and zone
                 const std::string& user_name = rule_obj["user-name"];
+                const std::string& user_zone = rule_obj["user-zone"];
                 auto& pin = plugin_instance_name;
 
                 auto proxy_conn = irods::proxy_connection();
-                rcComm_t* comm = proxy_conn.make( rule_obj["user-name"]);
+                rcComm_t* comm = proxy_conn.make( rule_obj["user-name"], rule_obj["user-zone"]);
 
-                auto status = irods::exec_as_user(comm, user_name, [& pin, & rule_obj](auto& comm) -> int{
+                auto status = irods::exec_as_user(comm, user_name, user_zone, [& pin, & rule_obj](auto& comm) -> int{
                                     return apply_data_movement_policy(
                                         comm,
                                         plugin_instance_name,
                                         rule_obj["object-path"],
                                         rule_obj["user-name"],
+                                        rule_obj["user-zone"],
                                         rule_obj["source-replica-number"],
                                         rule_obj["source-resource"],
                                         rule_obj["destination-resource"],
@@ -735,12 +742,13 @@ irods::error exec_rule_expression(
                                     });
 
                 irods::storage_tiering st{comm, rei, plugin_instance_name};
-                status = irods::exec_as_user(comm, user_name, [& st, & rule_obj](auto& comm) -> int{
+                status = irods::exec_as_user(comm, user_name, user_zone, [& st, & rule_obj](auto& comm) -> int{
                                     return apply_tier_group_metadata_policy(
                                         st,
                                         rule_obj["group-name"],
                                         rule_obj["object-path"],
                                         rule_obj["user-name"],
+                                        rule_obj["user-zone"],
                                         rule_obj["source-replica-number"],
                                         rule_obj["source-resource"],
                                         rule_obj["destination-resource"]);

--- a/packaging/test_plugin_unified_storage_tiering.py
+++ b/packaging/test_plugin_unified_storage_tiering.py
@@ -240,7 +240,7 @@ class TestStorageTieringPlugin(ResourceBase, unittest.TestCase):
             admin_session.assert_icommand('imeta add -R rnd2 irods::storage_tiering::group example_group 2')
             admin_session.assert_icommand('imeta add -R rnd0 irods::storage_tiering::time 5')
             admin_session.assert_icommand('imeta add -R rnd1 irods::storage_tiering::time 15')
-            admin_session.assert_icommand('''imeta set -R rnd1 irods::storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, DATA_REPL_NUM where RESC_NAME = 'ufs2' || = 'ufs3' and META_DATA_ATTR_NAME = 'irods::access_time' and META_DATA_ATTR_VALUE < 'TIME_CHECK_STRING'"''')
+            admin_session.assert_icommand('''imeta set -R rnd1 irods::storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, USER_ZONE, DATA_REPL_NUM where RESC_NAME = 'ufs2' || = 'ufs3' and META_DATA_ATTR_NAME = 'irods::access_time' and META_DATA_ATTR_VALUE < 'TIME_CHECK_STRING'"''')
             admin_session.assert_icommand('imeta add -R rnd0 irods::storage_tiering::minimum_delay_time_in_seconds 1')
             admin_session.assert_icommand('imeta add -R rnd0 irods::storage_tiering::maximum_delay_time_in_seconds 2')
             admin_session.assert_icommand('imeta add -R rnd1 irods::storage_tiering::minimum_delay_time_in_seconds 1')
@@ -485,7 +485,7 @@ class TestStorageTieringPluginMultiGroup(ResourceBase, unittest.TestCase):
             admin_session.assert_icommand('imeta add -R rnd2 irods::storage_tiering::group example_group 2')
             admin_session.assert_icommand('imeta add -R rnd0 irods::storage_tiering::time 5')
             admin_session.assert_icommand('imeta add -R rnd1 irods::storage_tiering::time 15')
-            admin_session.assert_icommand('''imeta set -R rnd1 irods::storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, DATA_REPL_NUM  where RESC_NAME = 'ufs2' || = 'ufs3' and META_DATA_ATTR_NAME = 'irods::access_time' and META_DATA_ATTR_VALUE < 'TIME_CHECK_STRING'"''')
+            admin_session.assert_icommand('''imeta set -R rnd1 irods::storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, USER_ZONE, DATA_REPL_NUM  where RESC_NAME = 'ufs2' || = 'ufs3' and META_DATA_ATTR_NAME = 'irods::access_time' and META_DATA_ATTR_VALUE < 'TIME_CHECK_STRING'"''')
 
             admin_session.assert_icommand('iadmin mkresc ufs0g2 unixfilesystem '+test.settings.HOSTNAME_1 +':/tmp/irods/ufs0g2', 'STDOUT_SINGLELINE', 'unixfilesystem')
             admin_session.assert_icommand('iadmin mkresc ufs1g2 unixfilesystem '+test.settings.HOSTNAME_1 +':/tmp/irods/ufs1g2', 'STDOUT_SINGLELINE', 'unixfilesystem')
@@ -498,7 +498,7 @@ class TestStorageTieringPluginMultiGroup(ResourceBase, unittest.TestCase):
             admin_session.assert_icommand('imeta add -R ufs0g2 irods::storage_tiering::time 5')
             admin_session.assert_icommand('imeta add -R ufs1g2 irods::storage_tiering::time 15')
 
-            admin_session.assert_icommand('''imeta set -R ufs1g2 irods::storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, DATA_REPL_NUM where RESC_NAME = 'ufs1g2' and META_DATA_ATTR_NAME = 'irods::access_time' and META_DATA_ATTR_VALUE < 'TIME_CHECK_STRING'"''')
+            admin_session.assert_icommand('''imeta set -R ufs1g2 irods::storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, USER_ZONE, DATA_REPL_NUM where RESC_NAME = 'ufs1g2' and META_DATA_ATTR_NAME = 'irods::access_time' and META_DATA_ATTR_VALUE < 'TIME_CHECK_STRING'"''')
             admin_session.assert_icommand('imeta add -R rnd0 irods::storage_tiering::minimum_delay_time_in_seconds 1')
             admin_session.assert_icommand('imeta add -R rnd0 irods::storage_tiering::maximum_delay_time_in_seconds 2')
             admin_session.assert_icommand('imeta add -R rnd1 irods::storage_tiering::minimum_delay_time_in_seconds 1')
@@ -602,7 +602,7 @@ class TestStorageTieringPluginCustomMetadata(ResourceBase, unittest.TestCase):
             admin_session.assert_icommand('imeta add -R rnd2 irods::custom_storage_tiering::group example_group 2')
             admin_session.assert_icommand('imeta add -R rnd0 irods::custom_storage_tiering::time 5')
             admin_session.assert_icommand('imeta add -R rnd1 irods::custom_storage_tiering::time 15')
-            admin_session.assert_icommand('''imeta set -R rnd1 irods::custom_storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, DATA_REPL_NUM where RESC_NAME = 'ufs2' || = 'ufs3' and META_DATA_ATTR_NAME = 'irods::custom_access_time' and META_DATA_ATTR_VALUE < 'TIME_CHECK_STRING'"''')
+            admin_session.assert_icommand('''imeta set -R rnd1 irods::custom_storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, USER_ZONE, DATA_REPL_NUM where RESC_NAME = 'ufs2' || = 'ufs3' and META_DATA_ATTR_NAME = 'irods::custom_access_time' and META_DATA_ATTR_VALUE < 'TIME_CHECK_STRING'"''')
             admin_session.assert_icommand('imeta add -R rnd0 irods::storage_tiering::minimum_delay_time_in_seconds 1')
             admin_session.assert_icommand('imeta add -R rnd0 irods::storage_tiering::maximum_delay_time_in_seconds 2')
             admin_session.assert_icommand('imeta add -R rnd1 irods::storage_tiering::minimum_delay_time_in_seconds 1')
@@ -929,7 +929,7 @@ class TestStorageTieringMultipleQueries(ResourceBase, unittest.TestCase):
         super(TestStorageTieringMultipleQueries, self).setUp()
         with session.make_session_for_existing_admin() as admin_session:
             admin_session.assert_icommand('iqdel -a')
-            admin_session.assert_icommand('''iadmin asq "select distinct R_DATA_MAIN.data_name, R_COLL_MAIN.coll_name, R_DATA_MAIN.data_owner_name, R_DATA_MAIN.data_repl_num from R_DATA_MAIN, R_COLL_MAIN, R_RESC_MAIN, R_OBJT_METAMAP r_data_metamap, R_META_MAIN r_data_meta_main where R_RESC_MAIN.resc_name = 'ufs0' AND r_data_meta_main.meta_attr_name = 'archive_object' AND r_data_meta_main.meta_attr_value = 'yes' AND R_COLL_MAIN.coll_id = R_DATA_MAIN.coll_id AND R_RESC_MAIN.resc_id = R_DATA_MAIN.resc_id AND R_DATA_MAIN.data_id = r_data_metamap.object_id AND r_data_metamap.meta_id = r_data_meta_main.meta_id order by R_COLL_MAIN.coll_name, R_DATA_MAIN.data_name" archive_query''')
+            admin_session.assert_icommand('''iadmin asq "select distinct R_DATA_MAIN.data_name, R_COLL_MAIN.coll_name, R_DATA_MAIN.data_owner_name, R_DATA_MAIN.data_owner_zone, R_DATA_MAIN.data_repl_num from R_DATA_MAIN, R_COLL_MAIN, R_RESC_MAIN, R_OBJT_METAMAP r_data_metamap, R_META_MAIN r_data_meta_main where R_RESC_MAIN.resc_name = 'ufs0' AND r_data_meta_main.meta_attr_name = 'archive_object' AND r_data_meta_main.meta_attr_value = 'yes' AND R_COLL_MAIN.coll_id = R_DATA_MAIN.coll_id AND R_RESC_MAIN.resc_id = R_DATA_MAIN.resc_id AND R_DATA_MAIN.data_id = r_data_metamap.object_id AND r_data_metamap.meta_id = r_data_meta_main.meta_id order by R_COLL_MAIN.coll_name, R_DATA_MAIN.data_name" archive_query''')
 
             admin_session.assert_icommand('iadmin mkresc ufs0 unixfilesystem '+test.settings.HOSTNAME_1 +':/tmp/irods/ufs0', 'STDOUT_SINGLELINE', 'unixfilesystem')
             admin_session.assert_icommand('iadmin mkresc ufs1 unixfilesystem '+test.settings.HOSTNAME_1 +':/tmp/irods/ufs1', 'STDOUT_SINGLELINE', 'unixfilesystem')
@@ -939,7 +939,7 @@ class TestStorageTieringMultipleQueries(ResourceBase, unittest.TestCase):
 
             admin_session.assert_icommand('imeta add -R ufs0 irods::storage_tiering::time 15')
 
-            admin_session.assert_icommand('''imeta add -R ufs0 irods::storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, DATA_REPL_NUM where RESC_NAME = 'ufs0' and META_DATA_ATTR_NAME = 'irods::access_time' and META_DATA_ATTR_VALUE < 'TIME_CHECK_STRING'"''')
+            admin_session.assert_icommand('''imeta add -R ufs0 irods::storage_tiering::query "SELECT DATA_NAME, COLL_NAME, USER_NAME, USER_ZONE, DATA_REPL_NUM where RESC_NAME = 'ufs0' and META_DATA_ATTR_NAME = 'irods::access_time' and META_DATA_ATTR_VALUE < 'TIME_CHECK_STRING'"''')
             admin_session.assert_icommand('''imeta add -R ufs0 irods::storage_tiering::query archive_query specific''')
             admin_session.assert_icommand('imeta add -R ufs0 irods::storage_tiering::minimum_delay_time_in_seconds 1')
             admin_session.assert_icommand('imeta add -R ufs0 irods::storage_tiering::maximum_delay_time_in_seconds 2')

--- a/proxy_connection.hpp
+++ b/proxy_connection.hpp
@@ -9,7 +9,7 @@ namespace irods {
         rErrMsg_t err_msg;
         rcComm_t* conn;
 
-        auto make(const std::string client = "") -> rcComm_t*
+        auto make(const std::string clientUser = "", const std::string clientZone = "") -> rcComm_t*
         {
             rodsEnv env{};
             _getRodsEnv(env);
@@ -19,10 +19,12 @@ namespace irods {
                        env.rodsPort,
                        env.rodsUserName,
                        env.rodsZone,
-                       !client.empty() ?
-                           client.c_str() :
+                       !clientUser.empty() ?
+                           clientUser.c_str() :
                            env.rodsUserName,
-                       env.rodsZone,
+                       !clientZone.empty() ?
+                           clientZone.c_str() :
+                           env.rodsZone,
                        &err_msg,
                        0, 0);
 

--- a/storage_tiering.cpp
+++ b/storage_tiering.cpp
@@ -448,7 +448,7 @@ namespace irods {
             metadata_results results;
             results.push_back(
                 std::make_pair(boost::str(
-                boost::format("SELECT DATA_NAME, COLL_NAME, USER_NAME, DATA_REPL_NUM WHERE META_DATA_ATTR_NAME = '%s' AND META_DATA_ATTR_VALUE < '%s' AND META_DATA_ATTR_UNITS <> '%s' AND DATA_RESC_ID IN (%s)")
+                boost::format("SELECT DATA_NAME, COLL_NAME, USER_NAME, USER_ZONE, DATA_REPL_NUM WHERE META_DATA_ATTR_NAME = '%s' AND META_DATA_ATTR_VALUE < '%s' AND META_DATA_ATTR_UNITS <> '%s' AND DATA_RESC_ID IN (%s)")
                 % config_.access_time_attribute
                 % tier_time
                 % config_.migration_scheduled_flag
@@ -568,7 +568,7 @@ namespace irods {
                     object_is_processed[object_path] = 1;
 
                     auto proxy_conn = irods::proxy_connection();
-                    rcComm_t* comm = proxy_conn.make(_results[2]);
+                    rcComm_t* comm = proxy_conn.make(_results[2], _results[3]);
 
                     if(preserve_replicas) {
                         if(skip_object_in_lower_tier(
@@ -586,6 +586,7 @@ namespace irods {
                         object_path,
                         _results[2],
                         _results[3],
+                        _results[4],
                         _source_resource,
                         _destination_resource,
                         get_verification_for_resc(comm, _destination_resource),
@@ -663,17 +664,18 @@ namespace irods {
         const std::string& _group_name,
         const std::string& _object_path,
         const std::string& _user_name,
+        const std::string& _user_zone,
         const std::string& _source_replica_number,
         const std::string& _source_resource,
         const std::string& _destination_resource,
         const std::string& _verification_type,
         const bool         _preserve_replicas,
         const std::string& _data_movement_params) {
-        if(object_has_migration_metadata_flag(_comm, _user_name, _object_path)) {
+        if(object_has_migration_metadata_flag(_comm, _user_name, _user_zone, _object_path)) {
             return;
         }
 
-        set_migration_metadata_flag_for_object(_comm, _user_name, _object_path);
+        set_migration_metadata_flag_for_object(_comm, _user_name, _user_zone, _object_path);
 
         nlohmann::json rule_obj =
         {
@@ -685,6 +687,7 @@ namespace irods {
                   , {"group-name",                _group_name}
                   , {"object-path",               _object_path}
                   , {"user-name",                 _user_name}
+                  , {"user-zone",                 _user_zone}
                   , {"source-replica-number",     _source_replica_number}
                   , {"source-resource",           _source_resource}
                   , {"destination-resource",      _destination_resource}
@@ -781,6 +784,7 @@ namespace irods {
     void storage_tiering::migrate_object_to_minimum_restage_tier(
         const std::string& _object_path,
         const std::string& _user_name,
+        const std::string& _user_zone,
         const std::string& _source_resource) {
 
         try {
@@ -808,6 +812,7 @@ namespace irods {
                 group_name,
                 _object_path,
                 _user_name,
+                _user_zone,
                 source_replica_number,
                 _source_resource,
                 low_tier_resource_name,
@@ -876,6 +881,7 @@ namespace irods {
     void storage_tiering::set_migration_metadata_flag_for_object(
         rcComm_t*          _comm,
         const std::string& _user_name,
+        const std::string& _user_zone,
         const std::string& _object_path) {
         auto access_time = get_metadata_for_data_object(
                                _comm,
@@ -890,7 +896,7 @@ namespace irods {
            const_cast<char*>(access_time.c_str()),
            const_cast<char*>(config_.migration_scheduled_flag.c_str())};
 
-        auto status = exec_as_user(_comm, _user_name, [&set_op](auto comm) -> int {
+        auto status = exec_as_user(_comm, _user_name, _user_zone, [&set_op](auto comm) -> int {
                             return rcModAVUMetadata(comm, &set_op);
                             });
         if(status < 0) {
@@ -904,6 +910,7 @@ namespace irods {
     void storage_tiering::unset_migration_metadata_flag_for_object(
         rcComm_t*          _comm,
         const std::string& _user_name,
+        const std::string& _user_zone,
         const std::string& _object_path) {
         auto access_time = get_metadata_for_data_object(
                                _comm,
@@ -917,7 +924,7 @@ namespace irods {
            const_cast<char*>(access_time.c_str()),
            nullptr};
 
-        const auto status = exec_as_user(_comm, _user_name, [&set_op](auto comm) -> int {
+        const auto status = exec_as_user(_comm, _user_name, _user_zone, [&set_op](auto comm) -> int {
                            return rcModAVUMetadata(comm, &set_op);
                            });
         if(status < 0) {
@@ -932,6 +939,7 @@ namespace irods {
     bool storage_tiering::object_has_migration_metadata_flag(
         rcComm_t*          _comm,
         const std::string& _user_name,
+        const std::string& _user_zone,
         const std::string& _object_path) {
         boost::filesystem::path p{_object_path};
         std::string coll_name = p.parent_path().string();
@@ -945,7 +953,7 @@ namespace irods {
                 % data_name
                 % coll_name) };
 
-        const auto status = exec_as_user(_comm, _user_name, [& query_str](auto& _comm) -> int {
+        const auto status = exec_as_user(_comm, _user_name, _user_zone, [& query_str](auto& _comm) -> int {
                             query<rcComm_t> qobj{_comm, query_str, 1};
                             return qobj.size();
                            });
@@ -958,11 +966,12 @@ namespace irods {
         const std::string& _group_name,
         const std::string& _object_path,
         const std::string& _user_name,
+        const std::string& _user_zone,
         const std::string& _source_replica_number,
         const std::string& _source_resource,
         const std::string& _destination_resource) {
         try {
-            unset_migration_metadata_flag_for_object(comm_, _user_name, _object_path);
+            unset_migration_metadata_flag_for_object(comm_, _user_name, _user_zone, _object_path);
         }
         catch(const exception&) {
         }

--- a/storage_tiering.hpp
+++ b/storage_tiering.hpp
@@ -36,6 +36,7 @@ namespace irods {
         void migrate_object_to_minimum_restage_tier(
                  const std::string& _object_path,
                  const std::string& _user_name,
+                 const std::string& _user_zone,
                  const std::string& _source_resource);
 
         void schedule_storage_tiering_policy(
@@ -46,6 +47,7 @@ namespace irods {
             const std::string& _group_name,
             const std::string& _object_path,
             const std::string& _user_name,
+            const std::string& _user_zone,
             const std::string& _source_replica_number,
             const std::string& _source_resource,
             const std::string& _destination_resource);
@@ -55,16 +57,19 @@ namespace irods {
         void set_migration_metadata_flag_for_object(
             rcComm_t*          _comm,
             const std::string& _user_name,
+            const std::string& _user_zone,
             const std::string& _object_path);
 
         void unset_migration_metadata_flag_for_object(
             rcComm_t*          _comm,
             const std::string& _user_name,
+            const std::string& _user_zone,
             const std::string& _object_path);
 
         bool object_has_migration_metadata_flag(
             rcComm_t*          _comm,
             const std::string& _user_name,
+            const std::string& _user_zone,
             const std::string& _object_path);
 
         bool skip_object_in_lower_tier(
@@ -154,6 +159,7 @@ namespace irods {
             const std::string& _group_name,
             const std::string& _object_path,
             const std::string& _user_name,
+            const std::string& _user_zone,
             const std::string& _source_replica_number,
             const std::string& _source_resource,
             const std::string& _destination_resource,


### PR DESCRIPTION
Hi,
This is a first try at adapting using storage tiering for data from remote sites.
The file `"exec_as_user.hpp"` has:
```
        rodsLog(
            LOG_ERROR,
                "executing as user [%s] fom zone [%s]",
                user.userName,
                user.rodsZone);
```
It shows that the correct user and remote zone is being used after the modifications:
```
{"log_category":"legacy","log_level":"error","log_message":"executing as user [robertv] fom zone [igor]","request_api_name":"EXEC_RULE_EXPRESSION_AN","request_api_number":1206,"request_api_version":"d","request_client_user":"rods","request_host":"145.100.3.238","request_proxy_user":"rods","request_release_version":"rods4.3.1","server_host":"irodstest1.storage.surfsara.nl","server_pid":22550,"server_timestamp":"2023-11-21T10:35:09.037Z","server_type":"agent","server_zone":"frank"}
```
But it is not executed as the correct user/remote zone. The following functions still fail.
```
{"log_category":"legacy","log_level":"error","log_message":"data movement scheduling failed - [-808000]::[iRODS Exception:\n    file: /home/robertv/git/irods_capability_storage_tiering/storage_tiering.cpp\n    function: std::string irods::storage_tiering::get_metadata_for_data_object(rcComm_t *, const std::string &, const std::string &)\n    line: 92\n    code: -808000 (CAT_NO_ROWS_FOUND)\n    message:\n        no results found for object [/frank/home/robertv#igor/test_20231121_01.txt] with attribute [irods::access_time]\nstack trace:\n--------------\n 0# irods::stacktrace::dump() const in /lib/libirods_common.so.4.3.1\n 1# irods::exception::assemble_full_display_what() const in /lib/libirods_common.so.4.3.1\n 2# irods::exception::what() const in /lib/libirods_common.so.4.3.1\n 3# irods::query_processor<RcComm>::execute(irods::thread_pool&, RcComm&)::'lambda'()::operator()() in /usr/lib/irods/plugins/rule_engines/libirods_rule_engine_plugin-unified_storage_tiering.so\n 4# boost::asio::detail::executor_op<boost::asio::detail::binder0<irods::query_processor<RcComm>::execute(irods::thread_pool&, RcComm&)::'lambda'()>, std::__1::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) in /usr/lib/irods/plugins/rule_engines/libirods_rule_engine_plugin-unified_storage_tiering.so\n 5# boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) in /lib/libirods_server.so.4.3.1\n 6# boost::asio::detail::scheduler::run(boost::system::error_code&) in /lib/libirods_server.so.4.3.1\n 7# boost::asio::detail::posix_thread::func<boost::asio::thread_pool::thread_function>::run() in /lib/libirods_server.so.4.3.1\n 8# boost_asio_detail_posix_thread_function in /lib/libirods_server.so.4.3.1\n 9# 0x00007FC191624EA5 in /lib64/libpthread.so.0\n10# clone in /lib64/libc.so.6\n\n]","request_api_name":"EXEC_RULE_EXPRESSION_AN","request_api_number":1206,"request_api_version":"d","request_client_user":"rods","request_host":"145.100.3.238","request_proxy_user":"rods","request_release_version":"rods4.3.1","server_host":"irodstest1.storage.surfsara.nl","server_pid":22550,"server_timestamp":"2023-11-21T10:35:09.095Z","server_type":"agent","server_zone":"frank"}
{"log_category":"legacy","log_level":"error","log_message":"iRODS Exception:\n    file: /home/robertv/git/irods_capability_storage_tiering/storage_tiering.cpp\n    function: void irods::storage_tiering::migrate_violating_data_objects(rcComm_t *, const std::string &, const std::string &, const std::string &, const std::string &)\n    line: 616\n    code: -35000 (SYS_INVALID_OPR_TYPE)\n    message:\n        scheduling failed for [1] objects for query [SELECT DATA_NAME, COLL_NAME, USER_NAME, USER_ZONE, DATA_REPL_NUM WHERE META_DATA_ATTR_NAME = 'irods::access_time' AND META_DATA_ATTR_VALUE < '1700562788' AND META_DATA_ATTR_UNITS <> 'irods::storage_tiering::migration_scheduled' AND DATA_RESC_ID IN ('10002',)]\nstack trace:\n--------------\n 0# irods::stacktrace::dump() const in /lib/libirods_common.so.4.3.1\n 1# irods::exception::assemble_full_display_what() const in /lib/libirods_common.so.4.3.1\n 2# irods::exception::what() const in /lib/libirods_common.so.4.3.1\n 3# irods::log(irods::exception const&) in /lib/libirods_common.so.4.3.1\n 4# irods::storage_tiering::migrate_violating_data_objects(RcComm*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in /usr/lib/irods/plugins/rule_engines/libirods_rule_engine_plugin-unified_storage_tiering.so\n 5# irods::storage_tiering::apply_policy_for_tier_group(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in /usr/lib/irods/plugins/rule_engines/libirods_rule_engine_plugin-unified_storage_tiering.so\n 6# exec_rule_expression(std::__1::tuple<>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, MsParamArray*, irods::callback) in /usr/lib/irods/plugins/rule_engines/libirods_rule_engine_plugin-unified_storage_tiering.so\n 7# std::__1::__function::__func<irods::error (*)(std::__1::tuple<>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, MsParamArray*, irods::callback), std::__1::allocator<irods::error (*)(std::__1::tuple<>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, MsParamArray*, irods::callback)>, irods::error (std::__1::tuple<>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, MsParamArray*, irods::callback)>::operator()(std::__1::tuple<>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, MsParamArray*&&, irods::callback&&) in /usr/lib/irods/plugins/rule_engines/libirods_rule_engine_plugin-unified_storage_tiering.so\n 8# irods::pluggable_rule_engine<std::__1::tuple<> >::exec_rule_expression(std::__1::tuple<>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, MsParamArray*, irods::callback) in /lib/libirods_server.so.4.3.1\n 9# irods::rule_engine_context_manager<std::__1::tuple<>, RuleExecInfo*, (irods::rule_execution_manager_pack)0>::exec_rule_expression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, MsParamArray*) in /lib/libirods_server.so.4.3.1\n10# rsExecRuleExpression(RsComm*, ExecRuleExpression*) in /lib/libirods_server.so.4.3.1\n11# irods::api_call_adaptor<ExecRuleExpression*>::operator()(irods::plugin_context&, RsComm*, ExecRuleExpression*) in /lib/libirods_server.so.4.3.1\n12# std::__1::__function::__func<irods::api_call_adaptor<ExecRuleExpression*>, std::__1::allocator<irods::api_call_adaptor<ExecRuleExpression*> >, irods::error (irods::plugin_context&, RsComm*, ExecRuleExpression*)>::operator()(irods::plugin_context&, RsComm*&&, ExecRuleExpression*&&) in /lib/libirods_server.so.4.3.1\n13# int irods::api_entry::call_handler<ExecRuleExpression*>(RsComm*, ExecRuleExpression*) in /lib/libirods_server.so.4.3.1\n14# rsApiHandler(RsComm*, int, BytesBuf*, BytesBuf*) in /lib/libirods_server.so.4.3.1\n15# readAndProcClientMsg(RsComm*, int) in /lib/libirods_server.so.4.3.1\n16# agentMain(RsComm*) in /lib/libirods_server.so.4.3.1\n17# runIrodsAgentFactory(sockaddr_un) in /lib/libirods_server.so.4.3.1\n18# main::$_5::operator()() const in /usr/sbin/irodsServer\n19# main in /usr/sbin/irodsServer\n20# __libc_start_main in /lib64/libc.so.6\n21# _start in /usr/sbin/irodsServer\n\n","request_api_name":"EXEC_RULE_EXPRESSION_AN","request_api_number":1206,"request_api_version":"d","request_client_user":"rods","request_host":"145.100.3.238","request_proxy_user":"rods","request_release_version":"rods4.3.1","server_host":"irodstest1.storage.surfsara.nl","server_pid":22550,"server_timestamp":"2023-11-21T10:35:09.198Z","server_type":"agent","server_zone":"frank"}

```

It still functions for files created by local users in the zone.

What did we mis?
Can you give us a pointer?

Greetings

