### PR TITLE
[irods/irods#6251] do not explicitly link to fmt (main)

### DIFF
--- a/unified_storage_tiering.cmake
+++ b/unified_storage_tiering.cmake
@@ -35,7 +35,6 @@ target_include_directories(
     ${IRODS_INCLUDE_DIRS}
     ${IRODS_EXTERNALS_FULLPATH_ARCHIVE}/include
     ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
-    ${IRODS_EXTERNALS_FULLPATH_FMT}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     )
 
@@ -46,7 +45,6 @@ target_link_libraries(
     ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so
     ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_regex.so
     ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
-    ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so
     OpenSSL::Crypto
     Threads::Threads
     irods_common


### PR DESCRIPTION
In service of irods/irods#6251

Ignore the branch name