### PR TITLE
Fix tiering with complex permissions and rodsusers running tiering rules (4-3-stable)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,8 +7,8 @@ Standard:        c++20
 ColumnLimit:     120
 UseCRLF:         false
 
-UseTab:          AlignWithSpaces
-#UseTab:          Never
+#UseTab:          AlignWithSpaces
+UseTab:          Never
 TabWidth:        4
 IndentWidth:     4
 ConstructorInitializerIndentWidth: 4
@@ -28,7 +28,7 @@ AlignConsecutiveDeclarations: None
 AlignConsecutiveMacros: AcrossEmptyLinesAndComments
 AlignEscapedNewlines: Left
 AlignOperands:   Align
-AlignTrailingComments: true
+AlignTrailingComments: false
 
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: false

--- a/include/irods/private/storage_tiering/proxy_connection.hpp
+++ b/include/irods/private/storage_tiering/proxy_connection.hpp
@@ -9,29 +9,58 @@ namespace irods {
         rErrMsg_t err_msg;
         rcComm_t* conn;
 
-        auto make(const std::string clientUser = "", const std::string clientZone = "") -> rcComm_t*
+        // Makes a proxy connection where the client is specified by the username in the parameters, and the proxy user
+        // is the service account rodsadmin for the local server.
+        auto make(const std::string& clientUser, const std::string& clientZone) -> rcComm_t*
         {
             rodsEnv env{};
             _getRodsEnv(env);
 
-            conn = _rcConnect(
-                       env.rodsHost,
-                       env.rodsPort,
-                       env.rodsUserName,
-                       env.rodsZone,
-                       !clientUser.empty() ?
-                           clientUser.c_str() :
-                           env.rodsUserName,
-                       !clientZone.empty() ?
-                           clientZone.c_str() :
-                           env.rodsZone,
-                       &err_msg,
-                       0, 0);
+            // TODO(#296): Handle any errors which occur in _rcConnect or clientLogin.
+            conn = _rcConnect(env.rodsHost,
+                              env.rodsPort,
+                              env.rodsUserName,
+                              env.rodsZone,
+                              clientUser.c_str(),
+                              clientZone.c_str(),
+                              &err_msg,
+                              0,
+                              0);
 
             clientLogin(conn);
 
             return conn;
         } // make
+
+        // Makes a proxy connection where both the proxy and client users are the service account rodsadmin for the
+        // local server.
+        auto make_rodsadmin_connection() -> RcComm*
+        {
+            rodsEnv env{};
+            _getRodsEnv(env);
+
+            // TODO(#296): Handle any errors which occur in _rcConnect or clientLogin.
+            conn = _rcConnect(env.rodsHost,
+                              env.rodsPort,
+                              env.rodsUserName,
+                              env.rodsZone,
+                              env.rodsUserName,
+                              env.rodsZone,
+                              &err_msg,
+                              0,
+                              0);
+
+            clientLogin(conn);
+
+            // Set the authFlag because auth plugin does not set it and the storage tiering plugin needs to know whether
+            // the client connection is privileged. This proxy connection uses the local client environment which should
+            // be the iRODS service account, a rodsadmin. If the local client environment is not a rodsadmin, the plugin
+            // will not function properly because it uses the ADMIN_KW and the server does not allow non-rodsadmins to
+            // use the ADMIN_KW.
+            conn->clientUser.authInfo.authFlag = LOCAL_PRIV_USER_AUTH;
+
+            return conn;
+        } // make_rodsadmin_connection
 
         ~proxy_connection() { rcDisconnect(conn); }
     }; // proxy_connection


### PR DESCRIPTION
Addresses #164 
Addresses #189 
Addresses #273
Addresses #293 

A few notes with this change:

1. Leaving in draft for now since I need to run the full test suite and make sure things are working when built against true-blue 4.3.3 packages. The build hook currently requires you to provide iRODS packages so I want to make extra sure I haven't been testing against tip of 4-3-stable or something that is not bit-for-bit identical to 4.3.3 iRODS packages.
2. I didn't change any of the internal interfaces (e.g. removing the user and zone parameters from function signatures), but we can update those if desired. Felt like a bit of a clean-up maneuver, distracting from the meat of the change.
3. "Run all storage tiering ops as admin" is not quite accurate as updating access_time metadata is not being done by rodsadmins in this change. That will come in a later change to address #175 and #203. The reason it is not included in this change is that this one is already quite big and testing for the updating of access_time for the read-only case is going to require yet more changes, so it felt better to leave those off of this PR. Can update that commit message if desired.
4. The tests provided here are very basic and may not be comprehensive. I made sure to hit the use cases in the linked issues, at least.