### PR TITLE
Add setup/teardown, fix failing tests (main) 

### DIFF
--- a/src/data_verification_utilities.cpp
+++ b/src/data_verification_utilities.cpp
@@ -81,6 +81,9 @@ namespace {
                 "'" + boost::str(boost::format("%s") % resc_id) + "',";
         }
 
+        // Pop off the trailing comma to ensure a valid query.
+        leaf_id_str.pop_back();
+
         return leaf_id_str;
 
     } // get_leaf_resources_string

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -582,19 +582,26 @@ namespace {
 
 } // namespace
 
-
-irods::error start(
-    irods::default_re_ctx&,
-    const std::string& _instance_name ) {
+auto setup(irods::default_re_ctx&, const std::string& _instance_name) -> irods::error
+{
     plugin_instance_name = _instance_name;
     RuleExistsHelper::Instance()->registerRuleRegex("pep_api_.*");
     config = std::make_unique<irods::storage_tiering_configuration>(plugin_instance_name);
     return SUCCESS();
+} // setup
+
+auto teardown(irods::default_re_ctx&, const std::string&) -> irods::error
+{
+    return SUCCESS();
+} // teardown
+
+auto start(irods::default_re_ctx&, const std::string&) -> irods::error
+{
+    return SUCCESS();
 } // start
 
-irods::error stop(
-    irods::default_re_ctx&,
-    const std::string& ) {
+auto stop(irods::default_re_ctx&, const std::string&) -> irods::error
+{
     return SUCCESS();
 } // stop
 
@@ -871,6 +878,10 @@ irods::pluggable_rule_engine<irods::default_re_ctx>* plugin_factory(
         new irods::pluggable_rule_engine<irods::default_re_ctx>(
                 _inst_name,
                 _context);
+
+    re->add_operation<irods::default_re_ctx&, const std::string&>("setup", std::function(setup));
+
+    re->add_operation<irods::default_re_ctx&, const std::string&>("teardown", std::function(teardown));
 
     re->add_operation<
         irods::default_re_ctx&,

--- a/src/storage_tiering.cpp
+++ b/src/storage_tiering.cpp
@@ -202,9 +202,11 @@ namespace irods {
         if(leaf_id_str.empty()) {
             rodsLong_t resc_id;
             resc_mgr.hier_to_leaf_id(_resource_name, resc_id);
-            leaf_id_str =
-                "'" + boost::str(boost::format("%s") % resc_id) + "',";
+            return fmt::format("'{}'", resc_id);
         }
+
+        // Pop off the trailing comma to ensure a valid query.
+        leaf_id_str.pop_back();
 
         return leaf_id_str;
 
@@ -250,7 +252,12 @@ namespace irods {
                                       _group_name);
         std::string resc_list;
         for(const auto& itr : idx_resc_map) {
-            resc_list += "'"+itr.second + "', ";
+            resc_list += "'" + itr.second + "',";
+        }
+
+        // Pop off the trailing comma to ensure a valid query.
+        if (!resc_list.empty()) {
+            resc_list.pop_back();
         }
 
         const auto query_str = fmt::format(
@@ -912,8 +919,13 @@ namespace irods {
 
         std::string partial_list{};
         for(; _itr != _end; ++_itr) {
-            partial_list += get_leaf_resources_string(_itr->second);
+            // get_leaf_resources_string pops off the trailing comma, so we must append it here for each partial list
+            // being concatenated.
+            partial_list += get_leaf_resources_string(_itr->second) + ",";
         }
+
+        // Pop off the trailing comma to ensure a valid query.
+        partial_list.pop_back();
 
         return partial_list;
 


### PR DESCRIPTION
Addresses #283 
In service of #290
Addresses #300 

Almost all the tests passed for postgres, but they failed on mysql. I'm guessing this has to do with https://github.com/irods/irods_capability_storage_tiering/issues/279, which is rooted in irods/irods#8154.

There is one test which did not pass that we can figure out separately as part of resolving #290 (hence, "In service of" rather than "Addresses" above). You can read about / discuss the failure here: https://github.com/irods/irods_capability_storage_tiering/issues/290#issuecomment-2773263784